### PR TITLE
Fix armature advanceTime when disposing in animation complete event

### DIFF
--- a/src/dragonBones/Armature.as
+++ b/src/dragonBones/Armature.as
@@ -233,7 +233,7 @@
 					{
 						this.dispatchEvent(event);
 					}
-					_eventList.length = 0;
+					if (_eventList != null) _eventList.length = 0;
 				}
 			}
 			else


### PR DESCRIPTION
We dispose armatures usually at the end of an animation. This cause a bug because the advanceTime method of Armature did not check if the fields were set to null after the animation complete event is broadcasted.
