### PR TITLE
public access to _currentTextureAtlas and _bitmapData for hit testing

### DIFF
--- a/src/dragonBones/factorys/BaseFactory.as
+++ b/src/dragonBones/factorys/BaseFactory.as
@@ -75,6 +75,11 @@ package dragonBones.factorys
 		{
 			return _dataDic[name];
 		}
+
+        public function get currentTextureAtlasName():String
+        {
+            return _currentTextureAtlasName;
+        }
 		
 		/**
 		 * Add a SkeletonData instance to this BaseFactory instance.

--- a/src/dragonBones/textures/StarlingTextureAtlas.as
+++ b/src/dragonBones/textures/StarlingTextureAtlas.as
@@ -45,6 +45,14 @@
 		{
 			return _name;
 		}
+        /**
+         * Atlas source BitmapData
+         */
+        public function get bitmapData():BitmapData
+        {
+            return _bitmapData;
+        }
+
 		/**
 		 * Creates a new StarlingTextureAtlas instance.
 		 * @param texture A texture instance.


### PR DESCRIPTION
for simple pixel perfect hittesting, yup there is no rotation and stuff, but in my case I have an big structures with small animations (like building with waving flags) its works almost perfecly

here is sample of code, you can include it, maybe its will be helpfull

public function hitTest(pTouch:Touch, pArmatureSprite:Sprite, pFactory:StarlingFactory):Boolean {
            var bitmap:BitmapData = pFactory.getTextureAtlas(pFactory.currentTextureAtlasName).bitmapData;

            for (var i:int = 0; i < pArmatureSprite.numChildren; i++) {
                var image:Image = pArmatureSprite.getChildAt(i) as Image;
                if (!image) {
                    continue;
                }

                var texture:SubTexture = image.texture as SubTexture;
                if (!texture) {
                    continue;
                }

                var clip:Rectangle = texture.clipping;

                var point:Point    = pTouch.getLocation(image);
                    point.x += bitmap.width  * clip.x;
                    point.y += bitmap.height * clip.y;

                var pixel:uint = bitmap.getPixel32(point.x, point.y);
                var alpha:int  = (pixel >> 24) & 0xFF;

                if (!alpha) {
                    continue;
                }

                return true;
            }

            return false;
        };